### PR TITLE
Update repository reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write \"{*,{src,test}/**/*}.+(js|css)\"",
     "release": "npm run -s prepare && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
-  "repository": "developit/microbundle",
+  "repository": "transitive-bullshit/microbundle",
   "prettier": {
     "singleQuote": true,
     "trailingComma": "all",


### PR DESCRIPTION
Found it quite misleading and confusing that the [npmjs page](https://www.npmjs.com/package/microbundle-crl) takes you to the original repo.