### PR TITLE
For bigger packages, specify Directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -679,14 +679,7 @@ function createConfig(options, entry, format, writeMeta) {
 			},
 			format: modern ? 'es' : format,
 			name: options.name,
-			file: resolve(
-				options.cwd,
-				{
-					modern: modernMain,
-					es: moduleMain,
-					umd: umdMain,
-				}[format] || cjsMain,
-			),
+      			dir:options.cwd+'/dist'
 		},
 	};
 


### PR DESCRIPTION
Fixes you must set "output.dir" instead of "output.file" when generating multiple chunks